### PR TITLE
feat: support `x-operation-name` and expose `apis.<tag>.<method>`

### DIFF
--- a/lib/openapi-connector.js
+++ b/lib/openapi-connector.js
@@ -31,7 +31,8 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
 
   dataSource.connector = connector;
   dataSource.connector.dataSource = dataSource;
-  connector.connect(callback);
+  // Call dataSource.connect to ensure state (connecting/connected) is consistent
+  dataSource.connect(callback);
 };
 
 /**
@@ -47,7 +48,6 @@ function OpenApiConnector(settings) {
   this.spec = settings.spec;
   this.cache = settings.cache;
   this.connectorHooks = new ConnectorHooks();
-  this.specResolver = new SpecResolver();
 
   if (debug.enabled) {
     debug('Settings: %j', settings);
@@ -83,7 +83,7 @@ OpenApiConnector.prototype.connect = function(cb) {
   }
 
   const validate = !!self.settings.validate;
-  self.specResolver.resolve(
+  new SpecResolver().resolve(
     self.spec,
     {validate: {schema: validate, spec: validate}},
     function(err, api) {

--- a/lib/openapi-connector.js
+++ b/lib/openapi-connector.js
@@ -136,35 +136,49 @@ OpenApiConnector.prototype.setupDataAccessObject = function() {
 
   this.specParsed = true;
 
+  const apis = {};
   for (const tag in this.client.apis) {
-    const api = this.client.apis[tag];
+    const operationsForTag = this.client.apis[tag];
+    apis[tag] = {};
 
-    for (const opName in api) {
-      const method = api[opName];
-      const methodName = this._methodName(tag, opName, this.DataAccessObject);
+    for (const operationId in operationsForTag) {
+      const opSpec = this.getOperationSpec(operationId);
+      const method = operationsForTag[operationId];
+      const operationName = opSpec['x-operation-name'] || operationId;
+      let methodName = this._methodName(tag, operationName, this.DataAccessObject);
 
       if (debug.enabled) {
         debug(
           'Adding method api=%s operation=%s as %s',
           tag,
-          opName,
+          operationId,
           methodName,
         );
       }
 
       const wrapper = createWrapper(
         method,
-        this.getOperationSpec(opName),
+        opSpec,
         this.settings,
       );
-      const swaggerMethod = wrapper.bind(api);
+      const swaggerMethod = wrapper.bind(operationsForTag);
       // TODO: gunjpan: support remotingEnabled
       // const swaggerOp = api.apis[o];
       // if (this.settings.remotingEnabled) {
       //   remoting.setRemoting.call(swaggerMethod, swaggerOp);
       // }
+      // Set findTodos()
       this.DataAccessObject[methodName] = swaggerMethod;
+      if (operationName !== operationId) {
+        // Set TodoController_findTodos()
+        methodName = this._methodName(tag, operationId, this.DataAccessObject);
+        this.DataAccessObject[methodName] = swaggerMethod;
+      }
+      // Set apis.TodoController.findTodos
+      apis[tag][operationName] = swaggerMethod;
     }
+    // Expose apis
+    this.DataAccessObject.apis = apis;
   }
 
   this.DataAccessObject.execute = (operationId, parameters, options) => {

--- a/lib/spec-resolver.js
+++ b/lib/spec-resolver.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const SwaggerParser = require('swagger-parser');
+const SwaggerParser = require('@apidevtools/swagger-parser');
 
 function SpecResolver() {
   this.parser = new SwaggerParser();

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "posttest": "npm run lint"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^9.0.1",
     "debug": "^4.1.1",
-    "js-yaml": "^3.12.2",
-    "swagger-client": "^3.8.25",
-    "swagger-parser": "^9.0.1"
+    "js-yaml": "^3.13.1",
+    "swagger-client": "^3.10.0"
   },
   "devDependencies": {
-    "@loopback/example-todo": "^3.1.0",
+    "@loopback/example-todo": "^3.1.1",
     "eslint": "^6.8.0",
-    "eslint-config-loopback": "^13.0.0",
+    "eslint-config-loopback": "^13.1.0",
     "loopback": "^3.27.0",
     "mocha": "^7.1.1",
     "p-event": "^4.0.0",

--- a/test/test-connector-openapi3.js
+++ b/test/test-connector-openapi3.js
@@ -100,6 +100,20 @@ describe('swagger connector for OpenApi 3.0', () => {
       }, /* on error */ done);
     });
 
+    it('supports model methods by x-operation-name', done => {
+      Todo.findTodos({filter}).then(function onSuccess(res) {
+        res.should.have.property('status', 200);
+        done();
+      }, /* on error */ done);
+    });
+
+    it('exports apis by tag', done => {
+      Todo.apis.TodoController.findTodos({filter}).then(function onSuccess(res) {
+        res.should.have.property('status', 200);
+        done();
+      }, /* on error */ done);
+    });
+
     it('allows models to be attached before the spec is loaded', async () => {
       const ds = await createDataSource('test/fixtures/3.0/ping.json');
       const Ping = ds.createModel('Ping', {});

--- a/test/test-connector-swagger2.js
+++ b/test/test-connector-swagger2.js
@@ -62,34 +62,32 @@ describe('OpenAPI connector for Swagger 2.0', function() {
   });
 
   describe('models', function() {
-    describe('models without remotingEnabled', function() {
-      let ds, PetService, petId;
-      before(async () => {
-        ds = await createDataSource('test/fixtures/2.0/petstore.json');
-        PetService = ds.createModel('PetService', {});
-        const data = await PetService.findPetsByStatus({status: 'available'});
-        should(data.body).be.Array();
-        should(data.body.length).be.above(0);
-        petId = data.body[0].id;
-      });
+    let ds, PetService, petId;
+    before('connect to pet store', async () => {
+      ds = await createDataSource('test/fixtures/2.0/petstore.json');
+      PetService = ds.createModel('PetService', {});
+      const data = await PetService.findPetsByStatus({status: 'available'});
+      should(data.body).be.Array();
+      should(data.body.length).be.above(0);
+      petId = data.body[data.body.length - 1].id;
+    });
 
-      it('creates models', () => {
-        (typeof PetService.getPetById).should.eql('function');
-        (typeof PetService.addPet).should.eql('function');
-      });
+    it('creates models', () => {
+      (typeof PetService.getPetById).should.eql('function');
+      (typeof PetService.addPet).should.eql('function');
+    });
 
-      it('supports model methods with callback', done => {
-        PetService.getPetById({petId}, function(err, res) {
-          if (err) return done(err);
-          res.status.should.eql(200);
-          done();
-        });
+    it('supports model methods with callback', (done) => {
+      PetService.getPetById({petId}, function(err, res) {
+        if (err) return done(err);
+        res.status.should.eql(200);
+        done();
       });
+    });
 
-      it('supports model methods returning a Promise', async () => {
-        const res = await PetService.getPetById({petId});
-        res.should.have.property('status', 200);
-      });
+    it('supports model methods returning a Promise', async () => {
+      const res = await PetService.getPetById({petId});
+      res.should.have.property('status', 200);
     });
 
     it('allows models to be attached before the spec is loaded', async () => {
@@ -102,10 +100,9 @@ describe('OpenAPI connector for Swagger 2.0', function() {
   });
 
   describe('Swagger invocations', function() {
-    let ds, PetService;
-    let petId = 1;
+    let ds, PetService, petId;
 
-    before(async () => {
+    before('connect to pet store', async () => {
       ds = await createDataSource('test/fixtures/2.0/petstore.json');
       PetService = ds.createModel('PetService', {});
 
@@ -113,7 +110,7 @@ describe('OpenAPI connector for Swagger 2.0', function() {
       const data = await PetService.findPetsByStatus({status: 'available'});
       should(data.body).be.Array();
       should(data.body.length).be.above(0);
-      petId = data.body[0].id;
+      petId = data.body[data.body.length - 1].id;
     });
 
     it('invokes the PetService', async () => {
@@ -131,7 +128,7 @@ describe('OpenAPI connector for Swagger 2.0', function() {
       res.headers['content-type'].should.eql('application/xml');
     });
 
-    it('invokes connector-hooks', done => {
+    it('invokes connector-hooks', (done) => {
       const events = [];
       const connector = ds.connector;
       connector.observe('before execute', function(ctx, next) {
@@ -150,16 +147,16 @@ describe('OpenAPI connector for Swagger 2.0', function() {
       });
     });
 
-    it('supports Promise-based connector-hooks', done => {
+    it('supports Promise-based connector-hooks', (done) => {
       const events = [];
       const connector = ds.connector;
 
-      connector.observe('before execute', ctx => {
+      connector.observe('before execute', (ctx) => {
         events.push('before execute');
         return Promise.resolve();
       });
 
-      connector.observe('after execute', ctx => {
+      connector.observe('after execute', (ctx) => {
         events.push('after execute');
         return Promise.resolve();
       });


### PR DESCRIPTION
I propose the following changes to allow `lb4 openapi --client` to nicely reflect REST APIs exposed by LB4 apps.

It allows the following access:

- Todo.TodoController_findTodos() // by operation id
- Todo.findTodos() // by x-operation-name
- Todo.apis.TodoController.findTodos() // by tag and x-operation-name or operation id

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-openapi) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
