### PR TITLE
Add ability to map methods and transform responses

### DIFF
--- a/lib/openapi-connector.js
+++ b/lib/openapi-connector.js
@@ -13,6 +13,7 @@ const SwaggerClient = require('swagger-client');
 const qs = require('querystring');
 const util = require('util');
 const fetch = require('node-fetch');
+const _ = require('lodash');
 
 /**
  * Export the initialize method to loopback-datasource-juggler
@@ -43,7 +44,9 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
  */
 function OpenApiConnector(settings) {
   settings = settings || {};
-
+  if (settings.transformResponse === true) {
+    settings.transformResponse = transformResponse;
+  }
   this.settings = settings;
   this.url = settings.url;
   this.spec = settings.spec;
@@ -142,6 +145,9 @@ OpenApiConnector.prototype.setupDataAccessObject = function() {
 
   this.specParsed = true;
 
+  const getMethodNames = this.settings.mapToMethods || mapToMethods;
+  const existingNames = Object.keys(this.DataAccessObject);
+
   const apis = {};
   for (const tag in this.client.apis) {
     const operationsForTag = this.client.apis[tag];
@@ -150,19 +156,19 @@ OpenApiConnector.prototype.setupDataAccessObject = function() {
     for (const operationId in operationsForTag) {
       const opSpec = this.getOperationSpec(operationId);
       const method = operationsForTag[operationId];
-      const operationName = opSpec['x-operation-name'] || operationId;
-      let methodName = this._methodName(
-        tag,
-        operationName,
-        this.DataAccessObject,
-      );
+
+      if (opSpec.operationId == null) {
+        opSpec.operationId = operationId;
+      }
+
+      let methodNames = getMethodNames(tag, opSpec, existingNames);
+      methodNames = normalizeMethods(methodNames);
 
       if (debug.enabled) {
         debug(
-          'Adding method api=%s operation=%s as %s',
-          tag,
+          'Adding methods for operation %s as %s',
           operationId,
-          methodName,
+          methodNames,
         );
       }
 
@@ -174,14 +180,24 @@ OpenApiConnector.prototype.setupDataAccessObject = function() {
       //   remoting.setRemoting.call(swaggerMethod, swaggerOp);
       // }
       // Set findTodos()
-      this.DataAccessObject[methodName] = swaggerMethod;
-      if (operationName !== operationId) {
-        // Set TodoController_findTodos()
-        methodName = this._methodName(tag, operationId, this.DataAccessObject);
-        this.DataAccessObject[methodName] = swaggerMethod;
+      for (const m of methodNames) {
+        this.DataAccessObject[m] = swaggerMethod;
       }
-      // Set apis.TodoController.findTodos
-      apis[tag][operationName] = swaggerMethod;
+
+      let methodNamesWithinTag = getMethodNames(undefined, opSpec);
+      methodNamesWithinTag = normalizeMethods(methodNamesWithinTag);
+      if (debug.enabled) {
+        debug(
+          'Adding apis[%s] for operation %s as %s',
+          tag,
+          operationId,
+          methodNamesWithinTag,
+        );
+      }
+      for (const m of methodNamesWithinTag) {
+        // Set apis.TodoController.findTodos
+        apis[tag][m] = swaggerMethod;
+      }
     }
     // Expose apis
     this.DataAccessObject.apis = apis;
@@ -207,7 +223,72 @@ OpenApiConnector.prototype.setupDataAccessObject = function() {
   return this.DataAccessObject;
 };
 
+/**
+ * Get the method name for an operation
+ * @param {string} tag - The tag. It will be undefined for tagged interfaces.
+ * @param {object} operationSpec - Operation spec
+ * @param {string[]} existingNames - Optional array to track used names
+ *
+ * @returns A method name or an array of method names. Return undefined to
+ * skip the operation.
+ */
+function mapToMethods(tag, operationSpec, existingNames) {
+  const methods = [];
+  const addMethods = (...names) => {
+    for (const name of names) {
+      if (!name) break;
+      if (methods.includes(name)) break;
+      methods.push(name);
+    }
+  };
+  const opName = operationSpec['x-operation-name'];
+  const opId = operationSpec.operationId;
+
+  // Add simple names
+  addMethods(opName, _.camelCase(opName));
+  addMethods(opId, _.camelCase(opId));
+
+  // Add full names
+  if (tag && opName) {
+    const name = `${tag}_${opName}`;
+    addMethods(name, _.camelCase(name));
+  }
+  if (tag && opId) {
+    const name = `${tag}_${opId}`;
+    addMethods(name, _.camelCase(opId));
+  }
+
+  if (existingNames == null) return methods;
+  return methods.filter((m) => {
+    if (existingNames.includes(m)) return false;
+    existingNames.push(m);
+    return true;
+  });
+}
+
+function normalizeMethods(methodNames) {
+  if (typeof methodNames === 'string') {
+    methodNames = [methodNames];
+  }
+  if (!Array.isArray(methodNames)) {
+    methodNames = [];
+  }
+  return methodNames;
+}
+
+function transformResponse(res) {
+  if (res.status < 400) {
+    return res.body;
+  }
+  const err = new Error(`${res.status} ${res.statusText}`);
+  err.details = res;
+  throw err;
+}
+
 function createWrapper(method, operation, options = {positional: false}) {
+  if (options.transformResponse === true) {
+    options.transformResponse = transformResponse;
+  }
   const methodWithCallback = util.callbackify(method);
   const params = operation.parameters || [];
   const argNames = params.map((p) => p.name);
@@ -236,9 +317,22 @@ function createWrapper(method, operation, options = {positional: false}) {
     }
     if (callbackFn) {
       // Callback style
-      return methodWithCallback(params, opts, callbackFn);
+      return methodWithCallback(params, opts, (err, res) => {
+        if (err || (typeof options.transformResponse !== 'function')) {
+          return callbackFn(err, res);
+        }
+        try {
+          res = options.transformResponse(res);
+          return callbackFn(err, res);
+        } catch (err) {
+          return callbackFn(err, res);
+        }
+      });
     } else {
-      return method(params, opts);
+      return method(params, opts).then(res => {
+        if (typeof options.transformResponse !== 'function') return res;
+        return options.transformResponse(res);
+      });
     }
   };
 }
@@ -264,28 +358,6 @@ OpenApiConnector.prototype.getOperationSpec = function(methodName) {
 OpenApiConnector.prototype.define = function(modelDef) {
   const modelName = modelDef.model.modelName;
   this._models[modelName] = modelDef;
-};
-
-/**
- * Find or derive the method name from apiName/operationName
- * @param {String} apiName The api name
- * @param {String} operationName The api operation name
- * @param {Object} dao The data access object
- * @returns {String} The method name
- * @private
- */
-
-OpenApiConnector.prototype._methodName = function(
-  apiName,
-  operationName,
-  dao,
-) {
-  if (dao && operationName in dao) {
-    // if operation name exists, create full name
-    return apiName + '_' + operationName;
-  } else {
-    return operationName;
-  }
 };
 
 // Setup connector hooks around execute operation

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@apidevtools/swagger-parser": "^9.0.1",
     "debug": "^4.1.1",
     "js-yaml": "^3.13.1",
+    "lodash": "^4.17.15",
     "node-fetch": "^2.6.0",
     "swagger-client": "^3.10.0"
   },


### PR DESCRIPTION
This feature allows `mapToMethods` and `transformResponse` to be configured to customize
method names and return values.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-openapi) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
