### PR TITLE
Allow 2.0 methods to positional with body as last arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Specify the options for the data source with the following properties.
 | validate          | When `true`, validates provided `spec` against Swagger specification 2.0 before initializing a data source.                                                                       | `false`     |
 | authorizations    | Security configuration for making authenticated requests to the API.                                                                                                              |             |
 | positional        | Use positional parameters instead of named parameters                                                                                                                             | `false`     |
+| forceOpenApi30    | Convert the Swagger 2.0 spec to OpenAPI 3.0                                                                                                                                       | `false`     |
 | mapToMethods      | map OpenAPI operations to method names                                                                                                                                            | `undefined` |
 | transformResponse | Transform the response object                                                                                                                                                     | `undefined` |
 
@@ -149,7 +150,7 @@ The return value can be transformed by a custom `transformResponse` function
 configured for the connector:
 
 ```js
-function transformResponse(res) {
+function transformResponse(res, operationSpec) {
   if (res.status < 400) {
     return res.body;
   }

--- a/lib/openapi-connector.js
+++ b/lib/openapi-connector.js
@@ -307,10 +307,12 @@ OpenApiConnector.prototype.createWrapper = function(
     .map((p) => p.name);
 
   // Add body as the last arg
+  let bodyName = '';
   if (swagger20) {
     const bodyParam = opParams.filter(isBodyParam)[0];
     if (bodyParam != null) {
-      argNames.push(bodyParam.name);
+      bodyName = bodyParam.name;
+      argNames.push(bodyName);
     }
   } else if (operation.requestBody) {
     argNames.push('requestBody');
@@ -334,8 +336,18 @@ OpenApiConnector.prototype.createWrapper = function(
           continue;
         params[name] = args[i];
       }
+      // `node-fetch` does not support JSON object directly. We have to
+      // call `JSON.stringify` to force it.
+      if (bodyName) {
+        if (params[bodyName] !== undefined) {
+          params[bodyName] = JSON.stringify(params[bodyName]);
+        }
+      }
       if (!swagger20 && operation.requestBody) {
         opts.requestBody = args[args.length - 1];
+        if (opts.requestBody !== undefined) {
+          opts.requestBody = JSON.stringify(opts.requestBody);
+        }
       }
     }
     if (callbackFn) {

--- a/lib/openapi-connector.js
+++ b/lib/openapi-connector.js
@@ -172,7 +172,7 @@ OpenApiConnector.prototype.setupDataAccessObject = function() {
         );
       }
 
-      const wrapper = createWrapper(method, opSpec, this.settings);
+      const wrapper = this.createWrapper(method, opSpec, this.settings);
       const swaggerMethod = wrapper.bind(operationsForTag);
       // TODO: gunjpan: support remotingEnabled
       // const swaggerOp = api.apis[o];
@@ -285,14 +285,34 @@ function transformResponse(res) {
   throw err;
 }
 
-function createWrapper(method, operation, options = {positional: false}) {
+OpenApiConnector.prototype.createWrapper = function(
+  method,
+  operation,
+) {
+  const options = this.settings;
   if (options.transformResponse === true) {
     options.transformResponse = transformResponse;
   }
+  // Force body to be the last argument for swagger 2.0
+  const swagger20 = this.api.swagger === '2.0';
+  const isBodyParam = (p) =>
+    swagger20 && options.positional === 'bodyLast' && p.in === 'body';
+
   const methodWithCallback = util.callbackify(method);
-  const params = operation.parameters || [];
-  const argNames = params.map((p) => p.name);
-  if (operation.requestBody) {
+  const opParams = operation.parameters || [];
+
+  // Arg names without body
+  const argNames = opParams
+    .filter((p) => !isBodyParam(p))
+    .map((p) => p.name);
+
+  // Add body as the last arg
+  if (swagger20) {
+    const bodyParam = opParams.filter(isBodyParam)[0];
+    if (bodyParam != null) {
+      argNames.push(bodyParam.name);
+    }
+  } else if (operation.requestBody) {
     argNames.push('requestBody');
   }
   return function(...args) {
@@ -307,18 +327,20 @@ function createWrapper(method, operation, options = {positional: false}) {
       params = {};
       for (let i = 0; i < argNames.length; i++) {
         const name = argNames[i];
-        if (!name || (i === argNames.length - 1 && name === 'requestBody'))
+        if (
+          !name ||
+          (!swagger20 && i === argNames.length - 1 && name === 'requestBody')
+        )
           continue;
         params[name] = args[i];
       }
-      if (operation.requestBody) {
+      if (!swagger20 && operation.requestBody) {
         opts.requestBody = args[args.length - 1];
       }
     }
     if (callbackFn) {
-      // Callback style
-      return methodWithCallback(params, opts, (err, res) => {
-        if (err || (typeof options.transformResponse !== 'function')) {
+      const cb = (err, res) => {
+        if (err || typeof options.transformResponse !== 'function') {
           return callbackFn(err, res);
         }
         try {
@@ -327,15 +349,18 @@ function createWrapper(method, operation, options = {positional: false}) {
         } catch (err) {
           return callbackFn(err, res);
         }
-      });
+      };
+      // Callback style
+      return methodWithCallback(params, opts, cb);
     } else {
-      return method(params, opts).then(res => {
+      const resolve = (res) => {
         if (typeof options.transformResponse !== 'function') return res;
         return options.transformResponse(res);
-      });
+      };
+      return method(params, opts).then(resolve);
     }
   };
-}
+};
 
 /**
  * Match the method name from SwaggerClient interfaces to corresponding

--- a/lib/openapi-connector.js
+++ b/lib/openapi-connector.js
@@ -14,6 +14,7 @@ const qs = require('querystring');
 const util = require('util');
 const fetch = require('node-fetch');
 const _ = require('lodash');
+const swagger2openapi = require('swagger2openapi');
 
 /**
  * Export the initialize method to loopback-datasource-juggler
@@ -68,19 +69,18 @@ function OpenApiConnector(settings) {
  * @param {Function} callback function
  * @prototype
  */
-
 OpenApiConnector.prototype.connect = function(cb) {
   const self = this;
 
   if (self.client) {
-    process.nextTick(function() {
+    process.nextTick(() => {
       if (cb) cb(null, self.client);
     });
     return;
   }
 
   if (!self.spec) {
-    process.nextTick(function() {
+    process.nextTick(() => {
       cb(new Error('No swagger specification provided'), null);
     });
     return;
@@ -94,35 +94,35 @@ OpenApiConnector.prototype.connect = function(cb) {
       // Ignore circular references
       dereference: {circular: 'ignore'},
     },
-    function(err, api) {
+    async function(err, api) {
       if (err) return cb(err, null);
 
       if (debug.enabled) {
         debug('Reading swagger specification from: %j', self.spec);
       }
 
-      self.api = api;
-      self.setupConnectorHooks();
-      const req = {
-        url: self.url,
-        spec: api,
-        userFetch: self.settings.userFetch || fetch,
-        authorizations: self.settings.authorizations || {},
-        requestInterceptor: self.connectorHooks.beforeExecute,
-        responseInterceptor: self.connectorHooks.afterExecute,
-      };
+      let error = null;
+      let client;
+      try {
+        if (self.settings.forceOpenApi30 && api.swagger === '2.0') {
+          const options = await swagger2openapi.convertObj(api, {
+            patch: true,
+            anchors: true,
+          });
+          api = options.openapi;
+        }
+        self.api = api;
+        self.setupConnectorHooks();
+        const req = {
+          url: self.url,
+          spec: api,
+          userFetch: self.settings.userFetch || fetch,
+          authorizations: self.settings.authorizations || {},
+          requestInterceptor: self.connectorHooks.beforeExecute,
+          responseInterceptor: self.connectorHooks.afterExecute,
+        };
 
-      SwaggerClient(req).then(
-        (client) => {
-          useClient(client);
-        },
-        (err) => {
-          const e = new Error(err);
-          cb(e, null);
-        },
-      );
-
-      function useClient(client) {
+        client = await SwaggerClient(req);
         if (debug.enabled) {
           debug('swagger loaded: %s', self.spec);
         }
@@ -130,8 +130,10 @@ OpenApiConnector.prototype.connect = function(cb) {
         client.connector = self;
         self.client = client;
         self.setupDataAccessObject();
-        cb(null, client);
+      } catch (err) {
+        error = err;
       }
+      cb(error, client);
     },
   );
 };
@@ -276,7 +278,7 @@ function normalizeMethods(methodNames) {
   return methodNames;
 }
 
-function transformResponse(res) {
+function transformResponse(res, operationSpec) {
   if (res.status < 400) {
     return res.body;
   }
@@ -324,9 +326,10 @@ OpenApiConnector.prototype.createWrapper = function(
       args.pop();
     }
     let params = args[0] || {};
-    const opts = args[1] || {};
+    let opts = args[1] || {};
     if (options.positional) {
       params = {};
+      opts = {};
       for (let i = 0; i < argNames.length; i++) {
         const name = argNames[i];
         if (
@@ -356,7 +359,7 @@ OpenApiConnector.prototype.createWrapper = function(
           return callbackFn(err, res);
         }
         try {
-          res = options.transformResponse(res);
+          res = options.transformResponse(res, operation);
           return callbackFn(err, res);
         } catch (err) {
           return callbackFn(err, res);
@@ -367,7 +370,7 @@ OpenApiConnector.prototype.createWrapper = function(
     } else {
       const resolve = (res) => {
         if (typeof options.transformResponse !== 'function') return res;
-        return options.transformResponse(res);
+        return options.transformResponse(res, operation);
       };
       return method(params, opts).then(resolve);
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "node-fetch": "^2.6.0",
-    "swagger-client": "^3.10.0"
+    "swagger-client": "^3.10.0",
+    "swagger2openapi": "^6.0.3"
   },
   "devDependencies": {
     "@loopback/example-todo": "^3.1.1",

--- a/test/test-connector-swagger2.js
+++ b/test/test-connector-swagger2.js
@@ -169,6 +169,36 @@ describe('OpenAPI connector for Swagger 2.0', function() {
   });
 });
 
+describe('options for openapi connector', () => {
+  let ds, PetService;
+
+  before(async () => {
+    ds = await createDataSource('test/fixtures/2.0/petstore.yaml', {
+      forceOpenApi30: true,
+      transformResponse: true,
+      positional: true,
+    });
+    PetService = ds.createModel('PetService', {});
+  });
+
+  it('supports forceOpenApi30', async () => {
+    const pet = await PetService.addPet({
+      category: {id: 0},
+      name: 'dog9375',
+      photoUrls: [],
+      tags: [],
+      status: 'available',
+    });
+    assert(pet.id);
+  });
+
+  it('supports positional & transformResponse', async () => {
+    // https://petstore.swagger.io/v2/pet/findByStatus?status=available
+    const data = await PetService.findPetsByStatus('available');
+    assert(data.length > 0);
+  });
+});
+
 async function createDataSource(spec, options) {
   const config = Object.assign(
     {


### PR DESCRIPTION
`lb4 openapi --client` command generates service proxies for swagger 2.0 specs after converting it to OpenAPI 3.0. As a result, we pass in `body` as the last argument. This PR allows so with `positional: 'bodyLast'` setting.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-openapi) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
