### PR TITLE
feat: allow extra options for operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
  - 10
  - 12
- - 13
+ - 14

--- a/README.md
+++ b/README.md
@@ -268,7 +268,17 @@ The `positional` setting allows a method to be invoked with positional parameter
 parameters/requestBody of the OpenAPI operation spec.
 
 ```js
-const result = await MyModel.my_operation('94555', {});
+const result = await MyModel.my_operation(
+  // Parameters
+  '94555',
+  // Request body
+  {
+    verbose: true
+  },
+  // Additional options
+  {
+    requestContentType: 'application/json'
+  });
 });
 ```
 
@@ -280,7 +290,8 @@ const result = await MyModel.my_operation({
     zipCode: '94555',
   },
   {
-    requestBody: {}
+    requestBody: {verbose: true},
+    requestContentType: 'application/json'
   }
 });
 ```

--- a/lib/openapi-connector.js
+++ b/lib/openapi-connector.js
@@ -310,8 +310,9 @@ OpenApiConnector.prototype.createWrapper = function(
 
   // Add body as the last arg
   let bodyName = '';
+  let bodyParam;
   if (swagger20) {
-    const bodyParam = opParams.filter(isBodyParam)[0];
+    bodyParam = opParams.filter(isBodyParam)[0];
     if (bodyParam != null) {
       bodyName = bodyParam.name;
       argNames.push(bodyName);
@@ -329,7 +330,11 @@ OpenApiConnector.prototype.createWrapper = function(
     let opts = args[1] || {};
     if (options.positional) {
       params = {};
-      opts = {};
+      // We allow an optional `options` argument for
+      // https://github.com/swagger-api/swagger-js/blob/master/docs/usage/try-it-out-executor.md
+      // https://github.com/swagger-api/swagger-js/blob/master/docs/usage/tags-interface.md
+      // Especially `requestContentType`, `responseContentType`, `authorizations`
+      opts = {...args[argNames.length]};
       for (let i = 0; i < argNames.length; i++) {
         const name = argNames[i];
         if (
@@ -341,15 +346,28 @@ OpenApiConnector.prototype.createWrapper = function(
       }
       // `node-fetch` does not support JSON object directly. We have to
       // call `JSON.stringify` to force it.
-      if (bodyName) {
-        if (params[bodyName] !== undefined) {
-          params[bodyName] = JSON.stringify(params[bodyName]);
+      if (bodyName && bodyParam) {
+        if (params[bodyName] != null) {
+          if (
+            opts.requestContentType === 'application/json' ||
+            (Array.isArray(operation.consumes) &&
+              operation.consumes.includes('application/json')) ||
+            operation.consumes.length === 0
+          ) {
+            params[bodyName] = JSON.stringify(params[bodyName]);
+          }
         }
       }
       if (!swagger20 && operation.requestBody) {
-        opts.requestBody = args[args.length - 1];
-        if (opts.requestBody !== undefined) {
-          opts.requestBody = JSON.stringify(opts.requestBody);
+        opts.requestBody = args[argNames.length - 1];
+        if (typeof opts.requestBody != null) {
+          if (
+            opts.requestContentType === 'application/json' ||
+            (operation.requestBody.content &&
+              operation.requestBody.content['application/json'])
+          ) {
+            opts.requestBody = JSON.stringify(opts.requestBody);
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "devDependencies": {
     "@loopback/example-todo": "^3.1.1",
-    "eslint": "^6.8.0",
+    "eslint": "^7.2.0",
     "eslint-config-loopback": "^13.1.0",
     "loopback": "^3.27.0",
-    "mocha": "^7.1.1",
-    "p-event": "^4.0.0",
+    "mocha": "^8.0.1",
+    "p-event": "^4.2.0",
     "should": "^13.2.3"
   },
   "repository": {

--- a/test/test-connector-openapi3.js
+++ b/test/test-connector-openapi3.js
@@ -165,6 +165,15 @@ describe('swagger connector for OpenApi 3.0', () => {
         res.body.should.eql({id: 2, title: 'My todo 2'});
       });
 
+      it('supports positional invocation with options', async () => {
+        const ds = await createDataSource(specUrl, {positional: true});
+        const Todo = ds.createModel('Todo', {}, {base: 'Model'});
+        const create = Todo.TodoController_createTodo({
+          title: 'My todo 2',
+        }, {requestContentType: 'application/xml'});
+        return should(create).rejectedWith(/Unprocessable Entity/);
+      });
+
       it('invokes the findTodos', async () => {
         const res = await Todo.TodoController_findTodos({filter});
         res.status.should.eql(200);


### PR DESCRIPTION
1. Allow the last positional param to be options
2. Call JSON.stringify only for json requests

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-openapi) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
